### PR TITLE
integrate btdigg search api (issue #198)

### DIFF
--- a/src/com/limegroup/gnutella/gui/GUILoader.java
+++ b/src/com/limegroup/gnutella/gui/GUILoader.java
@@ -29,15 +29,15 @@ import org.limewire.util.VersionUtils;
 import com.limegroup.gnutella.gui.bugs.FatalBugManager;
 import com.limegroup.gnutella.util.FrostWireUtils;
 
-
+//import com.limegroup.gnutella.gui.search.ApiSearchTests;
 /**
  * This class constructs an <tt>Initializer</tt> instance that constructs
  * all of the necessary classes for the application.
  */
 public class GUILoader {
-	
-	/** 
-	 * Creates an <tt>Initializer</tt> instance that constructs the 
+
+	/**
+	 * Creates an <tt>Initializer</tt> instance that constructs the
 	 * necessary classes for the application.
 	 *
 	 * <p>Invoked by com.limegroup.gnutella.gui.Main by reflection.
@@ -64,11 +64,13 @@ public class GUILoader {
                     t.initCause(err);
                     error = t;
                 } catch(Throwable ignored) {}
-                //System.out.println(t);       
+                //System.out.println(t);
                 showCorruptionError(error);
                 System.exit(1);
             }
         }
+
+//ApiSearchTests.main(args) ; //System.exit(0);
 	}
 
     private static void hideSplash(Frame frame) {
@@ -79,16 +81,16 @@ public class GUILoader {
             SplashWindow.instance().setVisible(false);
         } catch(Throwable ignored) {}
     }
-	
+
 	/**
 	 * Display a standardly formatted internal error message
 	 * coming from the backend.
 	 *
 	 * @param message the message to display to the user
 	 *
-	 * @param err the <tt>Throwable</tt> object containing information 
+	 * @param err the <tt>Throwable</tt> object containing information
 	 *  about the error
-	 */	
+	 */
 	private static final void showCorruptionError(Throwable err) {
 		err.printStackTrace();
 		StringWriter sw = new StringWriter();
@@ -107,14 +109,14 @@ public class GUILoader {
 		pw.println("Free/total memory: "
 				   +runtime.freeMemory()+"/"+runtime.totalMemory());
 		pw.println();
-		
+
         err.printStackTrace(pw);
-        
+
         pw.println();
-        
+
         pw.println("STARTUP ERROR!");
         pw.println();
-        
+
 		File propsFile = new File(getUserSettingsDir(), "frostwire.props");
 		Properties props = new Properties();
 		try {
@@ -126,12 +128,12 @@ public class GUILoader {
 		} catch(FileNotFoundException fnfe) {
 		} catch(IOException ioe) {
 		}
-		
+
 		pw.flush();
-		
+
         displayError(sw.toString());
 	}
-	
+
 	/**
 	 * Gets the settings directory without using CommonUtils.
 	 */
@@ -143,7 +145,7 @@ public class GUILoader {
         else
             return new File(dir, ".frostwire");
     }
-        
+
 	/**
 	 * Displays an internal error with specialized formatting.
 	 */
@@ -166,7 +168,7 @@ public class GUILoader {
 		String instr3;
 		String instr4;
 		String instr5;
-        
+
         instr0 = "One or more necessary files appear to be invalid.";
         instr1 = "This is generally caused by a corrupted installation.";
         instr2 = "Please try downloading and installing FrostWire again.";
@@ -180,7 +182,7 @@ public class GUILoader {
 		JLabel label3 = new JLabel(instr3);
 		JLabel label4 = new JLabel(instr4);
 		JLabel label5 = new JLabel(instr5);
-		
+
 		JPanel labelPanel = new JPanel();
 		JPanel innerLabelPanel = new JPanel();
 		labelPanel.setLayout(new BoxLayout(labelPanel, BoxLayout.X_AXIS));
@@ -228,7 +230,7 @@ public class GUILoader {
         mainPanel.add(buttonPanel, BorderLayout.SOUTH);
 
         DIALOG.getContentPane().add(mainPanel);
-        DIALOG.pack();        
+        DIALOG.pack();
 
 		Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
 		Dimension dialogSize = DIALOG.getSize();

--- a/src/com/limegroup/gnutella/gui/search/AbstractUISearchResult.java
+++ b/src/com/limegroup/gnutella/gui/search/AbstractUISearchResult.java
@@ -31,7 +31,7 @@ import com.limegroup.gnutella.settings.PlayerSettings;
 import com.limegroup.gnutella.settings.SearchSettings;
 
 /**
- * 
+ *
  * @author gubatron
  * @author aldenml
  *
@@ -44,6 +44,12 @@ public abstract class AbstractUISearchResult implements UISearchResult {
     private final String extension;
 
     public AbstractUISearchResult(FileSearchResult sr, SearchEngine se, String query) {
+
+System.out.println("AbstractUISearchResult::AbstractUISearchResult()" +
+                   " filename="  + sr.getFilename()                   +
+                   " sr.class="  + sr.getClass().getName()            +
+                   " extension=" + FilenameUtils.getExtension(sr.getFilename()));
+
         this.sr = sr;
         this.se = se;
         this.query = query;
@@ -121,7 +127,7 @@ public abstract class AbstractUISearchResult implements UISearchResult {
                 boolean isVideo = mediaType.equals(MediaType.getVideoMediaType());
                 if (isVideo) {
                     boolean videoPreviewInBrowser = !PlayerSettings.USE_FW_PLAYER_FOR_CLOUD_VIDEO_PREVIEWS.getValue() && sr instanceof YouTubeCrawledStreamableSearchResult;
-                    
+
                     if (videoPreviewInBrowser) {
                         GUIMediator.instance().launchYouTubePreviewInBrowser(((YouTubeCrawledStreamableSearchResult) sr));
                     } else {

--- a/src/com/limegroup/gnutella/gui/search/CompositeFilter.java
+++ b/src/com/limegroup/gnutella/gui/search/CompositeFilter.java
@@ -28,7 +28,7 @@ class CompositeFilter implements TableLineFilter<SearchResultDataLine> {
      * The underlying filters.
      */
     private List<TableLineFilter<SearchResultDataLine>> delegates;
-    
+
     /**
      * Creates a new CompositeFilter of the specified depth.
      * By default, all the filters are an AllowFilter.
@@ -40,7 +40,7 @@ class CompositeFilter implements TableLineFilter<SearchResultDataLine> {
         }
         reset();
     }
-    
+
     /**
      * Resets this filter to all AllowFilters.
      */
@@ -49,23 +49,32 @@ class CompositeFilter implements TableLineFilter<SearchResultDataLine> {
             delegates.set(i, AllowFilter.instance());
         }
     }
-    
+
     /**
      * Determines whether or not the specified TableLine
      * can be displayed.
      */
     public boolean allow(SearchResultDataLine line) {
+
+System.out.println("CompositeFilter::allow() nDelegates=" + delegates.size());
+
         for (int i=0; i<delegates.size(); i++) {
             if (! delegates.get(i).allow(line))
                 return false;
         }
         return true;
     }
-    
+
     /**
      * Sets the filter at the specified depth.
      */
     boolean setFilter(int depth, TableLineFilter<SearchResultDataLine> filter) {
+
+System.out.println("CompositeFilter::setFilter()"                 +
+                   " filter.class=" + filter.getClass().getName() +
+                   " isSelf?="      + (filter == this)            +
+                   " exists?="      + (delegates.get(depth).equals(filter)));
+
         if (filter == this) {
             throw new IllegalArgumentException("Filter must not be composed of itself");
         }

--- a/src/com/limegroup/gnutella/gui/search/GeneralResultFilter.java
+++ b/src/com/limegroup/gnutella/gui/search/GeneralResultFilter.java
@@ -23,7 +23,7 @@ import com.limegroup.gnutella.gui.GUIUtils;
 import com.limegroup.gnutella.gui.LabeledTextField;
 
 /**
- * 
+ *
  * @author gubatron
  * @author aldenml
  *
@@ -133,6 +133,13 @@ public final class GeneralResultFilter implements TableLineFilter<SearchResultDa
 
         String sourceName = getSourceName(node);
         boolean hasKeywords = hasKeywords(node.getDisplayName() + " " + node.getExtension() + " " + sourceName);
+
+System.out.println("GeneralResultFilter::allow()"                                +
+                   " inSeedRange?=" + inSeedRange                                +
+                   " inSizeRange?=" + inSizeRange                                +
+                   " hasKeywords?=" + hasKeywords                                +
+                   " ret="          + (inSeedRange && inSizeRange && hasKeywords));
+
         return inSeedRange && inSizeRange && hasKeywords;
     }
 

--- a/src/com/limegroup/gnutella/gui/search/MediaTypeFilter.java
+++ b/src/com/limegroup/gnutella/gui/search/MediaTypeFilter.java
@@ -21,7 +21,7 @@ package com.limegroup.gnutella.gui.search;
 import com.frostwire.gui.filters.TableLineFilter;
 
 /**
- * 
+ *
  * @author gubatron
  * @author aldenml
  *
@@ -49,6 +49,12 @@ final class MediaTypeFilter implements TableLineFilter<SearchResultDataLine> {
         } catch (Throwable e) {
             // ignore
         }
+
+NamedMediaType nodeType = node.getNamedMediaType();
+System.out.println("MediaTypeFilter::allow()"                                       +
+                   " nmt.name="  + nmt.getName()                                    +
+                   " node.name=" + ((nodeType == null)? "nil" : nodeType.getName()) +
+                   " ret="       + nmt.equals(node.getNamedMediaType()));
 
         return nmt.equals(node.getNamedMediaType());
     }

--- a/src/com/limegroup/gnutella/gui/search/SearchEngine.java
+++ b/src/com/limegroup/gnutella/gui/search/SearchEngine.java
@@ -35,6 +35,7 @@ import com.frostwire.search.frostclick.UserAgent;
 import com.frostwire.search.kat.KATSearchPerformer;
 import com.frostwire.search.mininova.MininovaSearchPerformer;
 import com.frostwire.search.monova.MonovaSearchPerformer;
+import com.frostwire.search.btdigg.BtdiggSearchPerformer;
 import com.frostwire.search.soundcloud.SoundcloudSearchPerformer;
 import com.frostwire.search.tbp.TPBSearchPerformer;
 import com.frostwire.search.torlock.TorLockSearchPerformer;
@@ -74,7 +75,8 @@ public abstract class SearchEngine {
     public static final int EZTV_ID = 15;
     public static final int TORRENTS_ID = 16;
     public static final int YIFI_ID = 17;
-    
+    public static final int BTDIGG_ID = 18;
+
     public static final DomainAliasManagerBroker DOMAIN_ALIAS_MANAGER_BROKER = new DomainAliasManagerBroker();
 
     public static final SearchEngine MININOVA = new SearchEngine(MININOVA_ID, "Mininova", SearchEnginesSettings.MININOVA_SEARCH_ENABLED, DOMAIN_ALIAS_MANAGER_BROKER.getDomainAliasManager("www.mininova.org")) {
@@ -182,7 +184,7 @@ public abstract class SearchEngine {
             return new TorrentsfmSearchPerformer(m, token, keywords, DEFAULT_TIMEOUT);
         }
     };
-    
+
     public static final SearchEngine YIFY = new SearchEngine(YIFI_ID, "Yify", SearchEnginesSettings.YIFY_SEARCH_ENABLED, DOMAIN_ALIAS_MANAGER_BROKER.getDomainAliasManager("www.yify-torrent.org")) {
         @Override
         public SearchPerformer getPerformer(long token, String keywords) {
@@ -191,7 +193,19 @@ public abstract class SearchEngine {
         }
     };
 
-    
+    public static final SearchEngine BTDIGG = new SearchEngine(BTDIGG_ID, "BtDigg", SearchEnginesSettings.BTDIGG_SEARCH_ENABLED, DOMAIN_ALIAS_MANAGER_BROKER.getDomainAliasManager("api.btdigg.org")) {
+        @Override
+        public SearchPerformer getPerformer(long token, String keywords) {
+            DomainAliasManager m = DOMAIN_ALIAS_MANAGER_BROKER.getDomainAliasManager("api.btdigg.org");
+            return new BtdiggSearchPerformer(m, token, keywords, DEFAULT_TIMEOUT);
+        }
+    };
+
+    public static final List<SearchEngine> SEARCH_ENGINES = Arrays.asList(
+            YOUTUBE, EXTRATORRENT, TPB, BITSNOOP, TORRENTS, SOUNDCLOUD, FROSTCLICK,
+            MININOVA, KAT, MONOVA, ARCHIVEORG, TORLOCK, EZTV, YIFY, BTDIGG);
+
+
     private SearchEngine(int id, String name, BooleanSetting setting, DomainAliasManager domainAliasManager) {
         _id = id;
         _name = name;
@@ -210,7 +224,7 @@ public abstract class SearchEngine {
     public String getName() {
         return _name;
     }
-    
+
     public String getDefaultDomain() {
         return _domainAliasManager.getDefaultDomain();
     }
@@ -225,7 +239,7 @@ public abstract class SearchEngine {
     }
 
     public static List<SearchEngine> getEngines() {
-        return Arrays.asList(YOUTUBE, EXTRATORRENT, TPB, BITSNOOP, TORRENTS, SOUNDCLOUD, FROSTCLICK, MININOVA, KAT, MONOVA, ARCHIVEORG, TORLOCK, EZTV, YIFY);
+        return SEARCH_ENGINES;
     }
 
     public abstract SearchPerformer getPerformer(long token, String keywords);
@@ -241,7 +255,7 @@ public abstract class SearchEngine {
 
         return null;
     }
-    
+
     /**
      * Used in Domain Alias Manifest QA test, don't delete.
      */

--- a/src/com/limegroup/gnutella/gui/search/SearchEngineFilter.java
+++ b/src/com/limegroup/gnutella/gui/search/SearchEngineFilter.java
@@ -20,6 +20,14 @@ class SearchEngineFilter implements TableLineFilter<SearchResultDataLine> {
         if (box != null) {
             result = node.getSearchEngine().isEnabled() && box.isEnabled() && box.isSelected();
         }
+
+System.out.println("SearchEngineFilter::allow()"                            +
+                   " box.null?="       + (box == null)                      +
+                   " node.isEnabled?=" + node.getSearchEngine().isEnabled() +
+                   " box.isEnabled?="  + (box != null && box.isEnabled())   +
+                   " box.isSelected?=" + (box != null && box.isSelected())  +
+                   " ret="             + result);
+
         return result;
     }
 }

--- a/src/com/limegroup/gnutella/gui/search/SearchMediator.java
+++ b/src/com/limegroup/gnutella/gui/search/SearchMediator.java
@@ -362,6 +362,9 @@ public final class SearchMediator {
     private static void updateSearchIcon(final long token, final boolean active) {
         GUIMediator.safeInvokeAndWait(new Runnable() {
             public void run() {
+
+System.out.println("SearchMediator::updateSearchIcon()");
+
                 SearchResultMediator trp = getResultPanelForGUID(token);
                 if (trp != null) {
                     trp.updateSearchIcon(active);
@@ -372,28 +375,42 @@ public final class SearchMediator {
 
     private static List<UISearchResult> convertResults(List<? extends SearchResult> results, SearchEngine engine, String query) {
 
-        List<UISearchResult> result = new ArrayList<UISearchResult>();
+System.out.println("SearchMediator::convertResults()  IN nResults=" + results.size());
+
+        List<UISearchResult> uiResults = new ArrayList<UISearchResult>();
 
         for (SearchResult sr : results) {
-
             UISearchResult ui = null;
+
+System.out.println("SearchMediator::convertResults() MID isTorrent displayName=" + ((TorrentSearchResult)sr).getDisplayName() + " sr.class=" + sr.getClass().getName());
 
             if (sr instanceof YouTubeCrawledSearchResult) {
                 ui = new YouTubeUISearchResult((YouTubeCrawledSearchResult) sr, engine, query);
             } else if (sr instanceof SoundcloudSearchResult) {
                 ui = new SoundcloudUISearchResult((SoundcloudSearchResult) sr, engine, query);
             } else if (sr instanceof TorrentSearchResult) {
+
+System.out.println("SearchMediator::convertResults() MID isTorrent filename=" + ((TorrentSearchResult)sr).getFilename());
+
                 ui = new TorrentUISearchResult((TorrentSearchResult) sr, engine, query);
             } else if (sr instanceof ArchiveorgCrawledSearchResult) {
                 ui = new ArchiveorgUISearchResult((ArchiveorgCrawledSearchResult) sr, engine, query);
             }
 
+else System.out.println("SearchMediator::convertResults() MID sr.class=NFG");
+System.out.println("SearchMediator::convertResults() MID (ui != null)=" + (ui != null));
+
             if (ui != null) {
-                result.add(ui);
+
+System.out.println("SearchMediator::convertResults() MID add filename=" + ui.getFilename());
+
+                uiResults.add(ui);
             }
         }
 
-        return result;
+System.out.println("SearchMediator::convertResults() OUT nResults=" + uiResults.size());
+
+        return uiResults;
     }
 
     /**
@@ -528,6 +545,8 @@ public final class SearchMediator {
     }
 
     private void onFinished(long token) {
+System.out.println("SearchMediator::onFinished()");
+
         SearchResultMediator rp = getResultPanelForGUID(token);
         updateSearchIcon(token, false);
         rp.setToken(0); // to identify that the search is stopped (needs refactor)
@@ -538,7 +557,7 @@ public final class SearchMediator {
         @Override
         public void onResults(SearchPerformer performer, List<? extends SearchResult> results) {
 
-System.out.println("ManagerListener::onResults() nResults" + results.size());
+System.out.println("ManagerListener::onResults() nResults" + results.size() + " token=" + performer.getToken());
 
             if (!performer.isStopped()) {
                 //System.out.println("Received results: " + performer.getToken() + " \t- " + results.size());
@@ -558,21 +577,25 @@ System.out.println("ManagerListener::onResults() nResults" + results.size());
                         }
 
                         final List<UISearchResult> uiResults = convertResults(filtered, se, rp.getQuery());
-
                         GUIMediator.safeInvokeAndWait(new Runnable() {
                             public void run() {
+
+System.out.println("ManagerListener::onResults() run()  IN nResults=" + uiResults.size());
                                 try {
                                     SearchFilter filter = getSearchFilterFactory().createFilter();
                                     for (UISearchResult sr : uiResults) {
                                         if (filter.allow(sr)) {
+
+System.out.println("ManagerListener::onResults() run() MID addQueryResult");
+
                                             getSearchResultDisplayer().addQueryResult(token, sr, rp);
                                         }
                                     }
                                 } catch (Exception e) {
                                     e.printStackTrace();
                                 }
+System.out.println("ManagerListener::onResults() run() OUT");
                             }
-
                         });
                     }
                 }
@@ -581,6 +604,9 @@ System.out.println("ManagerListener::onResults() nResults" + results.size());
 
         @Override
         public void onFinished(long token) {
+
+System.out.println("ManagerListener::onFinished()");
+
             //System.out.println("Finished: " + token);
             SearchMediator.this.onFinished(token);
         }

--- a/src/com/limegroup/gnutella/gui/search/SearchMediator.java
+++ b/src/com/limegroup/gnutella/gui/search/SearchMediator.java
@@ -118,7 +118,7 @@ public final class SearchMediator {
     }
 
     /**
-     * Constructs the UI components of the search result display area of the 
+     * Constructs the UI components of the search result display area of the
      * search tab.
      */
     private SearchMediator() {
@@ -156,7 +156,7 @@ public final class SearchMediator {
         GUIMediator.instance().getMainFrame().getApplicationHeader().requestSearchFocus();
     }
 
-    /** 
+    /**
      * Repeats the given search.
      */
     void repeatSearch(SearchResultMediator rp, SearchInformation info) {
@@ -188,13 +188,13 @@ public final class SearchMediator {
 
         long token = newSearchToken();
         SearchResultMediator resultTab = addResultTab(token, info);
-        
+
         performSearch(token, info.getQuery());
 
         if (info.getTitle().startsWith("youtube:")) {
             resultTab.selectSchemaBoxByMediaType(NamedMediaType.getFromMediaType(MediaType.getVideoMediaType()));
         }
-        
+
         return token;
     }
 
@@ -493,7 +493,7 @@ public final class SearchMediator {
 
     /**
      * Returns the <tt>ResultPanel</tt> for the specified GUID.
-     * 
+     *
      * @param rguid the guid to search for
      * @return the <tt>ResultPanel</tt> that matches the GUID, or null
      *  if none match.
@@ -537,6 +537,9 @@ public final class SearchMediator {
 
         @Override
         public void onResults(SearchPerformer performer, List<? extends SearchResult> results) {
+
+System.out.println("ManagerListener::onResults() nResults" + results.size());
+
             if (!performer.isStopped()) {
                 //System.out.println("Received results: " + performer.getToken() + " \t- " + results.size());
 

--- a/src/com/limegroup/gnutella/gui/search/SearchResultDisplayer.java
+++ b/src/com/limegroup/gnutella/gui/search/SearchResultDisplayer.java
@@ -66,11 +66,11 @@ public final class SearchResultDisplayer implements RefreshListener {
      */
     private SearchTabbedPane tabbedPane;
 
-    /** The contents of tabbedPane. 
-     *  INVARIANT: entries.size()==# of tabs in tabbedPane 
-     *  LOCKING: +obtain entries' monitor before adjusting number of 
+    /** The contents of tabbedPane.
+     *  INVARIANT: entries.size()==# of tabs in tabbedPane
+     *  LOCKING: +obtain entries' monitor before adjusting number of
      *            outstanding searches, i.e., the number of tabs
-     *           +obtain a ResultPanel's monitor before adding or removing 
+     *           +obtain a ResultPanel's monitor before adding or removing
      *            results + to prevent deadlock, never obtain ResultPanel's
      *            lock if holding entries'.
      */
@@ -95,7 +95,7 @@ public final class SearchResultDisplayer implements RefreshListener {
      */
     private SearchResultMediator DUMMY; // FTA: final removed
 
-    /** 
+    /**
      * Container for the DUMMY ResultPanel. I'm keeping a reference to this
      * object so that I can refresh the image that it contains.
      */
@@ -127,7 +127,7 @@ public final class SearchResultDisplayer implements RefreshListener {
         results = new JPanel();
 
         // make the results panel take up as much space as possible
-        // for when the window is resized. 
+        // for when the window is resized.
         results.setPreferredSize(new Dimension(10000, 10000));
         results.setLayout(switcher);
         //results.setBackground(Color.WHITE);
@@ -167,7 +167,7 @@ public final class SearchResultDisplayer implements RefreshListener {
 
         CancelSearchIconProxy.updateTheme();
     }
-    
+
     public void switchToTabByOffset(int offset) {
         if (tabbedPane != null) {
             tabbedPane.switchToTabByOffset(offset);
@@ -198,10 +198,10 @@ public final class SearchResultDisplayer implements RefreshListener {
             entries.get(i).refresh();
     }
 
-    /** 
+    /**
      * @modifies tabbed pane, entries
      * @effects adds an entry for a search for stext with GUID guid
-     *  to the tabbed pane.  This is used both for normal searching 
+     *  to the tabbed pane.  This is used both for normal searching
      *  and browsing.  Returns the ResultPanel added.
      */
     SearchResultMediator addResultTab(long token, List<String> searchTokens, SearchInformation info) {
@@ -233,7 +233,7 @@ public final class SearchResultDisplayer implements RefreshListener {
     /**
      * Create a new JTabbedPane and add the necessary
      * listeners.
-     * 
+     *
      */
     private void setupTabbedPane() {
         removeTabbedPaneListeners();
@@ -250,7 +250,7 @@ public final class SearchResultDisplayer implements RefreshListener {
      * titles from the current tabbed pane, create a new
      * tabbed pane and add all of the components and titles
      * back in.
-     * 
+     *
      */
     private void resetTabbedPane() {
         ArrayList<SearchResultMediator> ents = new ArrayList<SearchResultMediator>();
@@ -275,6 +275,9 @@ public final class SearchResultDisplayer implements RefreshListener {
     }
 
     private SearchResultMediator addResultPanelInternal(SearchResultMediator panel, String title) {
+
+System.out.println("SearchResultDisplayer::addResultPanelInternal()   IN title=" + title);
+
         entries.add(panel);
 
         // XXX: LWC-1214 (hack)
@@ -287,6 +290,8 @@ public final class SearchResultDisplayer implements RefreshListener {
             tabbedPane.addTab(title, CancelSearchIconProxy.createSelected(), panel.getComponent());
         }
 
+System.out.println("SearchResultDisplayer::addResultPanelInternal() MID1 title=" + title);
+
         // XXX: LWC-1088 (hack)
         try {
             tabbedPane.setSelectedIndex(entries.size() - 1);
@@ -298,7 +303,7 @@ public final class SearchResultDisplayer implements RefreshListener {
             tabbedPane.setSelectedIndex(entries.size() - 1);
 
             // This will happen under OS X in apple.laf.CUIAquaTabbedPaneTabState.getIndex().
-            // we grab all of the components from the current 
+            // we grab all of the components from the current
             // tabbed pane, create a new tabbed pane, and dump
             // the components back into it.
             //
@@ -306,11 +311,15 @@ public final class SearchResultDisplayer implements RefreshListener {
             // https://www.limewire.org/jira/browse/LWC-1088
         }
 
+System.out.println("SearchResultDisplayer::addResultPanelInternal() MID2 title=" + title);
+
         try {
             tabbedPane.setProgressActiveAt(entries.size() - 1, true);
         } catch (Exception e) {
             e.printStackTrace();
         }
+
+System.out.println("SearchResultDisplayer::addResultPanelInternal() MID3 title=" + title);
 
         //Make sure Parallel searches are not beyond the maximum to avoid CPU from burning
         if (SearchSettings.PARALLEL_SEARCH.getValue() > SearchSettings.MAXIMUM_PARALLEL_SEARCH) {
@@ -326,8 +335,10 @@ public final class SearchResultDisplayer implements RefreshListener {
         switcher.last(results); //show tabbed results
 
         // If there are lots of tabs, this ensures everything
-        // is properly visible. 
+        // is properly visible.
         MAIN_PANEL.revalidate();
+
+System.out.println("SearchResultDisplayer::addResultPanelInternal()  OUT title=" + title + " searchGuid=" + panel.getToken());
 
         return panel;
     }
@@ -336,19 +347,23 @@ public final class SearchResultDisplayer implements RefreshListener {
      * If i rp is no longer the i'th panel of this, returns silently. Otherwise
      * adds line to rp under the given group. Updates the count on the tab in
      * this and restarts the spinning lime.
-     * 
+     *
      * @requires this is called from Swing thread, group is null or similar to
      *           line and already in rp
      * @modifies this
      */
     void addQueryResult(long token, UISearchResult line, SearchResultMediator rp) {
+System.out.println("SearchResultDisplayer::addQueryResult()   IN query=" + rp.getQuery() + " searchGuid=" + token);
         if (rp.isStopped()) {
             return;
         }
+System.out.println("SearchResultDisplayer::addQueryResult() MID1 query=" + rp.getQuery() + " searchGuid=" + token);
 
         //Actually add the line.   Must obtain rp's monitor first.
         if (!rp.matches(token))//GUID of rp!=replyGuid
             throw new IllegalArgumentException("guids don't match");
+
+System.out.println("SearchResultDisplayer::addQueryResult() MID2 query=" + rp.getQuery() + " searchGuid=" + token);
 
         rp.add(line);
 
@@ -363,6 +378,8 @@ public final class SearchResultDisplayer implements RefreshListener {
         //Update index on tab.  Don't forget to add 1 since line hasn't
         //actually been added!
         tabbedPane.setTitleAt(resultPanelIndex, titleOf(rp));
+
+System.out.println("SearchResultDisplayer::addQueryResult()  OUT query=" + rp.getQuery() + " searchGuid=" + token);
     }
 
     void updateSearchIcon(SearchResultMediator rp, boolean active) {
@@ -570,7 +587,7 @@ public final class SearchResultDisplayer implements RefreshListener {
      */
     private String titleOf(SearchResultMediator rp) {
         int total = rp.totalResults();
-        
+
         String title = rp.getTitle();
         if (title.length() > 40) {
             title = title.substring(0,39) + "...";

--- a/src/com/limegroup/gnutella/gui/search/TableRowFilteredModel.java
+++ b/src/com/limegroup/gnutella/gui/search/TableRowFilteredModel.java
@@ -31,7 +31,7 @@ import com.limegroup.gnutella.settings.SearchSettings;
 public class TableRowFilteredModel extends ResultPanelModel {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -7810977044778830969L;
 
@@ -83,6 +83,11 @@ public class TableRowFilteredModel extends ResultPanelModel {
         boolean isNotJunk = junkFilter.allow(tl);
         boolean allow = allow(tl);
 
+System.out.println("TableRowFilteredModel::add()" +
+                   " isNotJunk?=" + isNotJunk     +
+                   " allow?="     + allow         +
+                   " hideJunk?="  + SearchSettings.hideJunk());
+
         if (isNotJunk || !SearchSettings.hideJunk()) {
             if (allow) {
                 return super.add(tl, row);
@@ -104,7 +109,7 @@ public class TableRowFilteredModel extends ResultPanelModel {
         HIDDEN.clear();
         super.simpleClear();
     }
-    
+
     @Override
     public void clear() {
         _numResults = 0;

--- a/src/com/limegroup/gnutella/gui/search/tests/ApiSearchTests.java
+++ b/src/com/limegroup/gnutella/gui/search/tests/ApiSearchTests.java
@@ -1,0 +1,140 @@
+package com.limegroup.gnutella.gui.search;
+
+import com.limegroup.gnutella.MediaType;
+import com.limegroup.gnutella.gui.search.SearchEngine;
+import com.limegroup.gnutella.gui.search.SearchInformation;
+import com.limegroup.gnutella.gui.search.SearchMediator;
+import com.limegroup.gnutella.gui.search.SearchResultMediator;
+//import com.limegroup.gnutella.gui.GUIMediator;
+
+import javax.swing.SwingUtilities;
+
+
+@SuppressWarnings("unused")
+public class ApiSearchTests {
+
+    /* constants */
+
+    private static final String BTDIGG_TEST_QUERY_VALID = "test BtDigg API search with valid query";
+    private static final String BTDIGG_QUERY_VALID = "mit ocw";
+    private static final String BTDIGG_TEST_QUERY_INVALID = "test BtDigg API search with invalid query";
+    private static final String BTDIGG_QUERY_INVALID = ""; // must be 1 or more chars
+    private static final String BTDIGG_TEST_QUERY_NONEXIST = "test BtDigg API search for non-existing torrent";
+    private static final String BTDIGG_QUERY_NONEXIST = "XnoX-XresultsX-XnoX-XsuchX-XtorrentX" ;
+
+    static long SearchGuid;
+    static SearchResultMediator ResultsPanel;
+    static int NExpectedResults = 0;
+    static boolean DidTestPass;
+
+
+    /* test steps */
+
+    private static void runSearchQuery(String engineName, String query) {
+
+        SearchEngine searchEngine = enableEngine(engineName);
+        if (searchEngine == null) return;
+
+        SearchGuid = startSearch(query);
+        if (SearchGuid == 0) return;
+
+// System.out.println("ApiSearchTests::runSearchQuery() query=" + query + " SearchGuid=" + SearchGuid);
+
+        ResultsPanel = SearchMediator.getResultPanelForGUID(SearchGuid);
+
+// if (ResultsPanel == null) System.out.println("ApiSearchTests::runSearchQuery() (resultsPanel == null)");
+    }
+
+    private static void getTestResult(int nExpectedResults, boolean shouldError) {
+
+        if (ResultsPanel == null) {
+            DidTestPass = shouldError;
+        } else {
+
+            int nActualResults = ResultsPanel.getSize(); // totalResults();
+            DidTestPass = (nExpectedResults == nActualResults);
+
+// System.out.println("ApiSearchTests::getNSearchResults() nResults=" + nActualResults + " size=" + nActualResul);
+        }
+    }
+
+
+    /* helpers */
+
+    private static void beforeEach() {
+        SearchGuid = 0; ResultsPanel = null; DidTestPass = false;
+    }
+
+    private static long startSearch(String query) {
+
+        MediaType mediaType = MediaType.getTorrentMediaType();
+        SearchInformation info = SearchInformation.createTitledKeywordSearch(query, null, mediaType, query);
+        long SearchGuid = SearchMediator.instance().triggerSearch(info);
+
+        return SearchGuid;
+    }
+
+    private static void sleep(int t) {
+        try { java.lang.Thread.sleep(t); } catch ( java.lang.InterruptedException ie) {}
+    }
+
+    private static SearchEngine enableEngine(String engineName) {
+
+        SearchEngine testEngine = null;
+
+        for (SearchEngine engine : SearchEngine.getEngines()) {
+            boolean isTestEngine = (engine.getName() == engineName);
+            engine.getEnabledSetting().setValue(isTestEngine);
+            if (isTestEngine) testEngine = engine;
+
+// System.out.println("ApiSearchTests::enableEngine() engine=" + engineName + " isEnabled=" + engine.isEnabled());
+        }
+
+        return testEngine;
+    }
+
+    private static String result(boolean didTestPass) {
+        return ((didTestPass)? "passed" : "failed");
+    }
+
+
+    /* main */
+
+    private static void runTest(String engineName, String testName, String query,
+                                int nExpectedResults, boolean shouldError) {
+
+        final String ENGINE_NAME = engineName;
+        final String TEST_NAME = testName;
+        final String QUERY = query;
+        final int N_EXPECTED_RESULTS = nExpectedResults;
+        final boolean SHOULD_ERROR = shouldError;
+
+        final Runnable RUN_SEARCH_QUERY = new Runnable() {
+            public void run() { runSearchQuery(ENGINE_NAME, QUERY); }
+        };
+
+        final Runnable GET_SEARCH_RESULTS = new Runnable() {
+            public void run() { getTestResult(N_EXPECTED_RESULTS, SHOULD_ERROR); }
+        };
+
+
+        beforeEach();
+
+        System.out.println("\n" + TEST_NAME);
+
+        sleep(1000);
+        try { SwingUtilities.invokeAndWait(RUN_SEARCH_QUERY); } catch (Exception ex) {}
+        sleep(5000);
+        try { SwingUtilities.invokeAndWait(GET_SEARCH_RESULTS); } catch (Exception ex) {}
+
+        System.out.println(TEST_NAME + " => " + result(DidTestPass));
+    }
+
+    public static void main(String[] args) {
+
+        System.out.println("ApiSearchTests"); sleep(1000);
+        runTest("BtDigg", BTDIGG_TEST_QUERY_VALID,    BTDIGG_QUERY_VALID,   10, false);
+        runTest("BtDigg", BTDIGG_TEST_QUERY_INVALID,  BTDIGG_QUERY_INVALID,  0, true);
+        runTest("BtDigg", BTDIGG_TEST_QUERY_NONEXIST, BTDIGG_QUERY_NONEXIST, 0, false);
+    }
+}

--- a/src/com/limegroup/gnutella/gui/search/tests/README-search-callchain.txt
+++ b/src/com/limegroup/gnutella/gui/search/tests/README-search-callchain.txt
@@ -1,0 +1,295 @@
+example model setup and callchain for searches
+
+this was compiled while implementing JSON API search queries
+    based on the existing PagedWebSearchPerformer class
+
+other search query types may be more or less similar
+
+feel free to add to this and/or create separate documents
+    for other search query types if they differ greatly as
+    this documentation will be invaluable for adding new search engines and query types
+
+
+NOTE:
+  the 'single-quoted' instance names within are intended to be unique and consistent
+      across the scope of this document and so do not match the variable names
+      used in the actual code which are not as consistent or descriptive as they could be
+
+
+============================================================
+ON STARTUP:
+
+------------------------------------------------------------
+SearchEngine.java
+  => creates public class constant list of SearchEngine 'SEARCH_ENGINES'
+  for each supported search engine named 'SOME'
+    => creates public class constant int 'SOME_ID'
+    => creates public class constant subclass singleton of SearchEngine 'SOME'
+       with a public method getPerformer()
+
+  SOME::getPerformer()
+    => returns a SomeSearchPerformer instance adding it to SEARCH_ENGINES
+
+NOTE:
+  in addition at least these following classes must be defined:
+    * SomeSearchPerformer
+    * SomeSearchResponse
+    * SomeSearchResult
+    * SomeSearchItem
+
+------------------------------------------------------------
+SearchEngineSettings.java
+  for each supported search engine named "SOME"
+    => creates public class constant instance of BooleanSetting 'SOME_SEARCH_ENABLED'
+       associated with the options enable/disable checkboxes
+       and stored as a private property of each *SearchEngine instance)
+       accessible via engine.getEnabledSetting() (.setValue() & .getValue())
+
+------------------------------------------------------------
+SearchMediator.java
+  => creates singleton of SearchMediator                  'searchMediator'
+  => creates singleton of SearchManagerImpl               'searchManagerImpl'
+  => creates singleton of SearchMediator::ManagerListener 'searchManagerListener'
+
+NOTE:
+  searchManagerImpl and searchManagerListener are not enforced singltons but they effectively are
+    as the SearchMediator singleton holds the only instantiated SearchManagerImpl and
+    that SearchManagerImpl instance holds the only instantiated ManagerListener
+
+------------------------------------------------------------
+SearchManagerImpl.java
+  => creates empty list of PerformTask 'performTasks'
+  => creates instance   of ThreadPool  'threadPool'
+
+------------------------------------------------------------
+SearchResultDisplayer.java
+  => creates singleton of SearchResultDisplayer 'searchResultDisplayer'
+  => creates empty list of SearchResultMediator 'searchResultMediators'
+
+NOTE:
+  searchResultDisplayer is not an enforced singleton but it effectively is
+    as the SearchMediator singleton holds the only instantiated SearchResultDisplayer
+    it is created lazily via SearchResultDisplayer::getSearchResultDisplayer()
+
+
+============================================================
+ON USER INITIATED SEARCH:
+
+------------------------------------------------------------
+ApplicationHeader.java
+  for singlton? instance of ApplicationHeader 'applicationHeader' (TODO:)
+  for applicationHeader instance of GoogleSearchField 'cloudSearchField'
+  * SearchListener::actionPerformed()
+    => gets instance of String 'query' (and indirectly 'queryTitle')
+       via cloudSearchField.getText();
+    => gets instance of MediaType 'mediaType'
+       via MediaType.getTorrentMediaType() (TODO: unclear why this is so specific)
+    => creates instance of SearchInformation 'info'
+       via SearchInformation::createTitledKeywordSearch(query, mediaType, queryTitle);
+    => gets singleton instance of SearchMediator 'searchMediator'
+       via SearchMediator::instance()
+    => calls searchMediator.triggerSearch()
+
+NOTE:
+  searchMediator.triggerSearch() is also called from: (TODO: under what circumstances?)
+  * SearchAction.java            => SearchAction::actionPerformed()
+  * MagnetClipboardListener.java => MagnetClipboardListener::handleMagnets()
+
+------------------------------------------------------------
+SearchMediator.java
+  for SearchMediator singleton of SearchMediator    'searchMediator'
+  for searchMediator singleton of SearchManagerImpl 'searchManagerImpl'
+
+  * searchMediator.triggerSearch()
+    for parameter of SearchInformation 'info'
+    => creates long 'searchGuid' via newSearchToken()
+    => calls SearchResultMediator::addResultTab(searchGuid, info)
+    => gets String 'query' via info.getQuery()
+    => calls searchMediator.performSearch(searchGuid, query)
+
+  * searchMediator.repeatSearch()
+    for parameter of SearchResultMediator 'searchResultMediator'
+    for parameter of SearchInformation    'info'
+    => gets long 'prevToken' via searchResultMediator.getToken()
+    => calls searchResultMediator.stopSearch(prevToken)
+    => creates long 'searchGuid' via searchMediator.newSearchToken()
+    => gets String 'query' via info.getQuery()
+    => calls searchMediator.performSearch(searchGuid, query)
+
+  * searchMediator.performSearch()
+    => gets list of SearchEngine 'searchEngines' via SearchEngine::getEngines()
+    for each instance of SearchEngine 'searchEngine' in searchEngines
+      => gets an instance of SearchPerformer 'searchPerformer'
+         via searchEngines.getPerformer()
+      => calls searchManagerImpl.perform(sp) if searchEngines.isEnabled()
+
+  * SearchMediator::addResultTab()
+    for long parameter                      'searchGuid'
+    for      parameter of SearchInformation 'info'
+    => get singleton instance of SearchMediator 'searchMediator'
+       via SearchMediator::instance()
+    => gets String 'query'
+       via info.getQuery()
+    => creates list of String 'queryTokens'
+       via searchMediator.tokenize(query)
+    => gets singleton of SearchResultDisplayer 'searchResultDisplayer'
+       via SearchMediator::getSearchResultDisplayer()
+    => gets instance of SearchResultMediator 'searchResultMediator'
+       via searchResultDisplayer.addResultTab(searchGuid, queryTokens, info)
+    => returns searchResultMediator
+
+------------------------------------------------------------
+SearchResultDisplayer.java
+  for singleton                  of SearchResultDisplayer 'searchResultDisplayer'
+  for searchResultDisplayer list of SearchResultMediator  'searchResultMediators'
+
+  * searchResultDisplayer.addResultTab()
+    for long parameter                      'searchGuid'
+    for list parameter of String            'queryTokens'
+    for      parameter of SearchInformation 'info'
+    => creates instance of SearchResultMediator 'searchResultMediator'
+       via SearchResultMediator(searchGuid, queryTokens, info)
+    => gets String 'title' via info.getTitle()
+    => calls searchResultDisplayer.addResultPanelInternal(searchResultMediator, title)
+    => returns 'searchResultMediator'
+
+  * searchResultDisplayer.addResultPanelInternal()
+    for parameter of SearchResultMediator 'searchResultMediator'
+    for parameter of String               'title'
+    => adds searchResultMediator to searchResultMediators
+    => returns searchResultMediator
+
+------------------------------------------------------------
+SearchManagerImpl.java
+  for SearchMediator    singleton of SearchMediator    'searchMediator' (outside class)
+  for searchMediator    singleton of SearchManagerImpl 'searchManagerImpl'
+  for searchManagerImpl instance  of ThreadPool        'threadPool'
+
+  * searchManagerImpl.perform()
+    for parameter of SearchPerformer 'searchPerformer'
+    => creates an instance of PerformerResultListener 'performerResultListener'
+       via PerformerResultListener(searchManagerImpl)
+    => creates an instance of PerformTask             'performTask'
+       via PerformTask(searchPerformer)
+    => calls sp.registerListener(performerResultListener)
+    => calls searchManagerImpl.submitSearchTask(performTask)
+
+  * searchManagerImpl.submitSearchTask()
+    for parameter of PerformTask 'performTask'
+    => adds performTask to performTasks
+    => calls tp.executeTask(performTask)
+
+  * (some asynchonous magic happens)
+    => then performerResultListener::onResults() fires
+
+------------------------------------------------------------
+PerformerResultListener.java
+  * PerformerResultListener::PerformerResultListener()
+    for parameter of SearchManagerImpl 'searchManagerImpl'
+    => stores reference to searchManagerImpl on new instance
+
+
+============================================================
+ON SEARCH RESULTS:
+
+------------------------------------------------------------
+PerformerResultListener.java
+  for performerResultListener singleton of SearchManagerImpl 'searchManagerImpl'
+  * performerResultListener.onResults()
+    for      parameter of SearchPerformer 'searchPerformer'
+    for list parameter of SearchResult    'searchResults'
+    => creates List<SearchResult> 'completedSearchResults' and populates like:
+      for each instance of SearchResult 'searchResult' in searchResults
+        if searchResult is instance of CrawlableSearchResult
+             but not searchResult.isComplete()
+          => defer adding but call searchManagerImpl.crawl(searchPerformer, searchResult)
+             whereby some more asynchonous magic happens?
+        else
+          => completedSearchResults.add()
+    => calls searchManagerImpl.onResults(searchPerformer, completedSearchResults)
+
+------------------------------------------------------------
+SearchManagerImpl.java
+  for SearchMediator    singleton of SearchMediator    'searchMediator' (outside class)
+  for searchMediator    singleton of SearchManagerImpl 'searchManagerImpl'
+  for searchManagerImpl singleton of ManagerListener   'searchManagerListener'
+
+  * smi.onResults()
+    for      parameter of SearchPerformer 'searchPerformer'
+    for list parameter of SearchResult    'searchResults'
+    => calls searchManagerListener.onResults(searchPerformer, searchResults)
+
+------------------------------------------------------------
+SearchMediator.java
+  for SearchMediator    singleton of SearchMediator    'searchMediator'
+  for searchMediator    singleton of SearchManagerImpl 'searchManagerImpl'
+  for searchManagerImpl singleton of ManagerListener   'searchManagerListener'
+
+  * searchManagerListener.onResults()
+    for      parameter of SearchPerformer 'searchPerformer'
+    for list parameter of SearchResult    'searchResults'
+    => gets             long                 'searchGuid'
+       via searchPerformer.getToken()
+    => gets instance of SearchResultMediator 'searchResultMediator'
+       via SearchMediator::getResultPanelForGUID(searchGuid)
+    => gets list     of String               'queryTokens'
+       via searchResultMediator.getSearchTokens()
+    => creates list  of SearchResult         'filteredSearchResults'
+       via sm.filter(searchPerformer, searchResults, queryTokens)
+    => gets instance of SearchResult         'searchResult'
+       from head of filteredSearchResults
+    => gets instance of SearchEngine         'searchEngine'
+       via SearchEngine::getSearchEngineByName(searchResult)
+    => gets instance of string               'query'
+       via searchResultMediator.getQuery()
+    => gets list     of UISearchResult 'uISearchResults'
+       via SearchMediator::convertResults(filteredSearchResults, searchEngine, query)
+    for each instance of UISearchResult 'uISearchResult' in uISearchResults
+      => gets singleton of SearchResultDisplayer 'searchResultDisplayer'
+         via SearchMediator::getSearchResultDisplayer()
+      => calls searchResultDisplayer.addQueryResult(searchGuid, uISearchResult, searchResultMediator)
+
+  * SearchMediator::getResultPanelForGUID()
+    for long parameter of searchGuid
+    => gets singleton of SearchResultDisplayer 'searchResultDisplayer'
+        via SearchMediator::getSearchResultDisplayer()
+    => gets instance of SearchResultMediator 'searchResultMediator'
+        via searchResultDisplayer.getResultPanelForGUID(searchGuid)
+    => returns SearchResultMediator
+
+  * SearchMediator::convertResults()
+    for list parameter of SearchResult 'searchResults'
+    for      parameter of SearchEngine 'searchEngine'
+    for      parameter of String       'query'
+    => creates list of UISearchResult 'uISearchResults' and populates like:
+      map each instance of SearchResult 'searchResult' in searchResults
+        case searchResult instance of
+          * YouTubeCrawledSearchResult
+            => YouTubeUISearchResult(searchResult, searchEngine, query)
+          * SoundcloudSearchResult
+            => SoundcloudUISearchResultsearchResult, searchEngine, query)
+          * TorrentSearchResult
+            => TorrentUISearchResult(searchResult, searchEngine, query)
+          * ArchiveorgCrawledSearchResult
+            => ArchiveorgUISearchResult(searchResult, searchEngine, query)
+    => returns uISearchResults
+
+------------------------------------------------------------
+SearchResultDisplayer.java
+  for SearchResultDisplayer singleton of SearchResultDisplayer 'searchResultDisplayer'
+  for searchResultDisplayer list      of SearchResultMediator  'searchResultMediators'
+
+  * searchResultDisplayer.getResultPanelForGUID()
+    for long parameter 'searchGuid'
+    => finds matching instance of SearchResultMediator 'searchResultMediator'
+       in 'searchResultMediators'
+    => returns searchResultMediator
+
+
+============================================================
+TODO:
+* which events lead to *SearchPerformer::searchPage()
+* when are GeneralResultFilter, MediaTypeFilter, SearchEngineFilter created?
+  and what is the fourth one? especially for MediaTypeFilter
+  (seems to be created in SearchResultDataLine::initialize()
+  per NamedMediaType.getFromExtension using extension from *SearchResult)

--- a/src/com/limegroup/gnutella/gui/tables/AbstractTableMediator.java
+++ b/src/com/limegroup/gnutella/gui/tables/AbstractTableMediator.java
@@ -160,9 +160,9 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
     private static TableCellRenderer ICON_AND_NAME_RENDERER;
 
     private static TableCellRenderer ACTION_ICON_AND_NAME_RENDERER;
-    
+
     private static SourceRenderer SOURCE_RENDERER;
-    
+
     private static SearchResultActionsRenderer SEARCH_RESULT_ACTIONS_RENDERER;
 
     /**
@@ -177,10 +177,10 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
 
     /** Variable for the date renderer. */
     private static TableCellRenderer DATE_RENDERER;
-    
-    
+
+
     private static NameHolderRenderer NAME_HOLDER_RENDERER;
-    
+
     /**
      * A zero dimension to be used in all tables.
      */
@@ -203,7 +203,7 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
     protected JScrollPane SCROLL_PANE;
 
     /**
-     * Is true when the table is currently resorted. Should only be used by 
+     * Is true when the table is currently resorted. Should only be used by
      * package internal event listeners, which want to suppress events during
      * resorting.
      */
@@ -398,7 +398,7 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
         TABLE.setDefaultRenderer(SpeedRenderer.class, getSpeedRenderer());
         TABLE.setDefaultRenderer(Date.class, getDateRenderer());
         TABLE.setDefaultRenderer(NameHolder.class, getNameHolderRenderer());
-        
+
         if (getAbstractActionsRenderer() != null) {
             TABLE.setDefaultRenderer(AbstractActionsHolder.class, getAbstractActionsRenderer());
         }
@@ -411,11 +411,11 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
     /**
      * Intended for setting up default editors.  By default,
      * no editors are added.
-     * 
+     *
      * Important: Make sure to NOT REUSE Renderers used for non-editable cells.
      * It's necessary for editors to have their own Renderer instance, otherwise
      * you might get issues painting on editable cells. -gubatron
-     * 
+     *
      */
     protected void setDefaultEditors() {
     }
@@ -469,14 +469,14 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
         tablePane.setLayout(new BoxLayout(tablePane, BoxLayout.Y_AXIS));
 
         SCROLL_PANE = new JScrollPane(TABLE);
-        
+
         tablePane.add(SCROLL_PANE);
 
         TABLE_PANE = tablePane;
 
         return tablePane;
     }
-    
+
     public T getDataModel() {
         return DATA_MODEL;
     }
@@ -494,7 +494,7 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
      * Adds a new DataLine initialized by Object o to the list at
      * index i. If the list is sorted or the insert is beyond the list bounds
      * the add falls back to the default add(Object o)
-     * 
+     *
      * @param o - object to add
      * @param index - index to insert into if the list is not sorted
      */
@@ -503,8 +503,6 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
             CellEditor editor = TABLE.getCellEditor();
             editor.cancelCellEditing();
         }
-
-        boolean inView = TABLE.isSelectionVisible();
 
         int addedAt;
         if (SETTINGS.REAL_TIME_SORT.getValue() && DATA_MODEL.isSorted())
@@ -517,8 +515,10 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
             }
         }
 
+System.out.println("AbstractTableMediator::add() isSelectionVisible?=" + TABLE.isSelectionVisible());
+
         // if it was added...
-        fixSelection(addedAt, inView);
+        fixSelection(addedAt, TABLE.isSelectionVisible());
     }
 
     /**
@@ -575,7 +575,7 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
     }
 
     /**
-     * Moves a row in the table to a new location. 
+     * Moves a row in the table to a new location.
      * @param oldLocation - table row to move
      * @param newLocation - location to insert the table row after it had been removed
      */
@@ -653,7 +653,7 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
     /**
      * Removes all selected rows from the list
      * and fires deletions through the dataModel
-     * 
+     *
      * Cancels any editing that may be occuring prior to updating the model, we
      * must do this since editing will be occuring on the row that will be
      * removed
@@ -932,7 +932,7 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
     }
 
     /**
-     * Returns whether the table is resorting. 
+     * Returns whether the table is resorting.
      */
     boolean isResorting() {
         return isResorting;
@@ -979,21 +979,21 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
         }
         return SOURCE_RENDERER;
     }
-    
+
     protected TableCellRenderer getActionIconAndNameRenderer() {
         if (ACTION_ICON_AND_NAME_RENDERER == null) {
             ACTION_ICON_AND_NAME_RENDERER = new ActionIconAndNameRenderer();
         }
         return ACTION_ICON_AND_NAME_RENDERER;
     }
-    
+
     protected TableCellRenderer getSearchResultsActionsRenderer() {
         if (SEARCH_RESULT_ACTIONS_RENDERER == null) {
             SEARCH_RESULT_ACTIONS_RENDERER = new SearchResultActionsRenderer();
         }
         return SEARCH_RESULT_ACTIONS_RENDERER;
     }
-    
+
     protected TableCellRenderer getDefaultRenderer() {
         if (DEFAULT_RENDERER == null) {
             DEFAULT_RENDERER = new DefaultTableBevelledCellRenderer();//new DefaultTableCellRenderer();
@@ -1014,7 +1014,7 @@ public abstract class AbstractTableMediator<T extends DataLineModel<E, I>, E ext
         }
         return DATE_RENDERER;
     }
-    
+
     private TableCellRenderer getNameHolderRenderer() {
         if (NAME_HOLDER_RENDERER == null) {
             NAME_HOLDER_RENDERER = new NameHolderRenderer();

--- a/src/com/limegroup/gnutella/gui/tables/LimeJTable.java
+++ b/src/com/limegroup/gnutella/gui/tables/LimeJTable.java
@@ -134,6 +134,9 @@ public class LimeJTable extends JTable implements JSortTable {
      * See: http://developer.java.sun.com/developer/bugParade/bugs/4730055.html
      */
     public int getSelectedRow() {
+
+System.out.println("LimeJTable::getSelectedRow() row=" + super.getSelectedRow() + " nRows=" + dataModel.getRowCount() + " dataModel.class=" + dataModel.getClass().getName());
+
         int selected = super.getSelectedRow();
         if (selected >= dataModel.getRowCount())
             return -1;
@@ -197,6 +200,9 @@ public class LimeJTable extends JTable implements JSortTable {
      * Determines if the given row is visible.
      */
     public boolean isRowVisible(int row) {
+
+System.out.println("LimeJTable::isRowVisible() row=" + row);
+
         if (row != -1) {
             Rectangle cellRect = getCellRect(row, 0, false);
             Rectangle visibleRect = getVisibleRect();
@@ -342,7 +348,7 @@ public class LimeJTable extends JTable implements JSortTable {
                 getSelectionModel().addSelectionInterval(reselectIndex, reselectIndex);
             }
 
-            // deselect rows if 
+            // deselect rows if
             if (e.getID() == MouseEvent.MOUSE_CLICKED && SwingUtilities.isLeftMouseButton(e) && !e.isPopupTrigger()) {
 
                 TableModel model = getModel();
@@ -376,16 +382,16 @@ public class LimeJTable extends JTable implements JSortTable {
         int col = columnAtPoint(p);
 
         TableCellRenderer cellRenderer = getCellRenderer(row, col);
-        
+
         if (cellRenderer instanceof FWAbstractJPanelTableCellRenderer) {
             FWAbstractJPanelTableCellRenderer renderer = (FWAbstractJPanelTableCellRenderer) cellRenderer;
-            String tooltip = renderer.getToolTipText(e); 
+            String tooltip = renderer.getToolTipText(e);
             if (tooltip != null) {
                 this.tips = new String[] {tooltip};
                 return tooltip;
             }
         }
-        
+
         int colModel = convertColumnIndexToModel(col);
         DataLineModel<?, ?> dlm = (DataLineModel<?, ?>) dataModel;
         boolean isClippable = col > -1 && row > -1 ? dlm.isClippable(colModel) : false;
@@ -531,12 +537,12 @@ public class LimeJTable extends JTable implements JSortTable {
     }
 
     /**
-     * Returns the next list element that starts with 
+     * Returns the next list element that starts with
      * a prefix.
      *
      * @param prefix the string to test for a match
      * @param startIndex the index for starting the search
-     * @param bias the search direction, either 
+     * @param bias the search direction, either
      * Position.Bias.Forward or Position.Bias.Backward.
      * @return the index of the next list element that
      * starts with the prefix; otherwise -1

--- a/src/com/limegroup/gnutella/settings/SearchEnginesSettings.java
+++ b/src/com/limegroup/gnutella/settings/SearchEnginesSettings.java
@@ -56,6 +56,8 @@ public class SearchEnginesSettings extends LimeProps {
     public static final BooleanSetting EZTV_SEARCH_ENABLED = FACTORY.createBooleanSetting("EZTV_SEARCH_ENABLED", true);
 
     public static final BooleanSetting TORRENTS_SEARCH_ENABLED = FACTORY.createBooleanSetting("TORRENTS_SEARCH_ENABLED", true);
-    
+
     public static final BooleanSetting YIFY_SEARCH_ENABLED = FACTORY.createBooleanSetting("YIFY_SEARCH_ENABLED", true);
+
+    public static final BooleanSetting BTDIGG_SEARCH_ENABLED = FACTORY.createBooleanSetting("BTDIGG_SEARCH_ENABLED", true);
 }


### PR DESCRIPTION
initial btdigg implementation (issue #198)
* depends on frostwire-common search-engines branch ([PR #7](https://github.com/frostwire/frostwire-common/pull/7))
* sends GET request to api.btdigg.org and decodes response
* de-serializes JSON response and passes objects to GUI
* displays search results in the GUI
* added documentation for the call chain initiated by search queries
* added some simple GUI acceptance tests

NOTES:
* this feature appears to be working well but is not quite completed and many breadcrumbs left behind but i offer PR for evaluation and critique
* results were hidden because a valid filename extension is required
    for a proper result but this is not enforced and so was not obvious
    the source of this bug took some digging to uncover and resulted in the callchain document included 
    the BtDigg results do not contain any filenames only magnet links so this was kludged for now

TODO:
* implement paged queries (capped at 10 results for now)
* assert valid file extension for result or at least print something to console
    indicating that the filetype of this result is unsupported 
    but is for some reason deemed acceptable although it will be inaccesible
* add '.magnet' filetype or extension to '.torrent' filetype
    adding .magnet filetype to the .torrent schema should be trivial - the only reason ive come across for a distinct .magnet filetype would be so that it could sport a different icon
* connect details page (if it is not yet working) and add string for tooltip? in SearchMediator.java like:
    static final String ARCHIVEORG_DETAILS_STRING = I18n.tr("View in Archive.org");
* figure out what is a Crawlable to ensure this is the proper *SearchPreformer class for JSON API paged queries
* dry out AbstractTorrentSearchResult sublasses and move AbstractTorrentSearchResult to outer dir
